### PR TITLE
Add assignment statement

### DIFF
--- a/docs/grammar/grammar.peg
+++ b/docs/grammar/grammar.peg
@@ -25,11 +25,14 @@ BlockExpression <- OpenBrace Statement* CloseBrace
 Statement <-
     ( Expression
     / VariableDeclarationStatement
+    / AssignStatement
     / ReturnStatement
     ) EndOfStatement
 
 VariableDeclarationStatement <- VariableDeclaration (OperAssign Expression)?
 VariableDeclaration <- TypeIdentifier Identifier
+
+AssignStatement <- Identifier AssignOperator Expression
 
 ReturnStatement <- KeyW_return Expression
 
@@ -137,8 +140,10 @@ KeyW_main   <- 'main'   EndOfWord AnySpacing
 ### Operators ###
 # All operators allow line breaks, hence the AnySpacing
 
-#// Assignments can't be made in expressions for now
-# AssignOperator <- OperAssign
+AssignOperator <- OperAssign
+    # / OperAssignAdd
+    # / OperAssignSub
+    # (for when have more assign operators)
 
 LogicalOrOperator <- OperOr
 

--- a/src/Parser/AST.hs
+++ b/src/Parser/AST.hs
@@ -33,6 +33,7 @@ newtype BlockExpression = BlockExpression [Statement]
 data Statement
     = StExpression Expression
     | StVariableDecl VariableDeclaration (Maybe Expression)
+    | StAssignment VarIdentifier Expression
     | StReturn Expression
     deriving (Eq, Show)
 

--- a/src/Parser/Shorthands.hs
+++ b/src/Parser/Shorthands.hs
@@ -37,6 +37,7 @@ eoAnd a b = ExprOperation $ OpInfix $ InfixAnd a b
 sRet = StReturn
 sDecl t n = StVariableDecl (VariableDeclaration t n)
 sExpr = StExpression
+sAssi t = StAssignment (VarIdentifier t)
 
 fn text params retType sts = Function text params retType (BlockExpression sts)
 fnMain params sts = MainFunction params (BlockExpression sts)

--- a/src/Parser2.hs
+++ b/src/Parser2.hs
@@ -248,7 +248,7 @@ pVariableDeclStatement = do
     return $ StVariableDecl decl value
 
 pStatement :: Parser Statement
-pStatement = choice
+pStatement = choice $ map (<* pEndOfStatement)
     [ pReturnStatement
     , pVariableDeclStatement
     , pExpression <&> StExpression
@@ -262,7 +262,7 @@ pEndOfStatement = do
 
 pBlockExpression :: Parser BlockExpression
 pBlockExpression = BlockExpression <$>
-    pBetweenBrace (many (pStatement <* pEndOfStatement))
+    pBetweenBrace (many pStatement)
 
 pFunParamList :: Parser [VariableDeclaration]
 pFunParamList = (pControl OpenParen *> manyEol *> pFunParamList') <|> pure []

--- a/src/Parser2.hs
+++ b/src/Parser2.hs
@@ -235,6 +235,7 @@ pReturnStatement :: Parser Statement
 pReturnStatement = StReturn <$> (pKeyword KeyWReturn *> pExpression)
 
 pVariableDecl :: Parser VariableDeclaration
+-- We might be able to remove the `try` here if type ids and var ids are different tokens
 pVariableDecl = try (VariableDeclaration
     <$> pTypeIdentifier
     <*> pVarIdentifier
@@ -247,10 +248,20 @@ pVariableDeclStatement = do
     value <- tryParse (pControl OperAssign *> pExpression)
     return $ StVariableDecl decl value
 
+pAssignStatement :: Parser Statement
+pAssignStatement = try (StAssignment
+    <$> pVarIdentifier
+    <* pControl OperAssign
+    <* manyEol
+    <*> pExpression
+    <?> "assignment statement"
+    )
+
 pStatement :: Parser Statement
 pStatement = choice $ map (<* pEndOfStatement)
     [ pReturnStatement
     , pVariableDeclStatement
+    , pAssignStatement
     , pExpression <&> StExpression
     ]
 

--- a/test/ParserSpec.hs
+++ b/test/ParserSpec.hs
@@ -20,8 +20,7 @@ import Parser2 (
     pExpression,
     pTypeIdentifier,
     pVariableDecl,
-    pReturnStatement,
-    pVariableDeclStatement,
+    pStatement,
     pBlockExpression,
     pFunction,
     pMainFunction,
@@ -30,6 +29,7 @@ import Parser2 (
 import Parser.WithPos(withPos)
 import Lexer (showLexError, alexScanTokens)
 import Lexer.Tokens (
+    Token(..),
     ControlSequence(..),
     )
 import Parser.ParseAndLex (
@@ -202,13 +202,13 @@ spec = do
 
     describe "basic statements" $ do
         it "return statement" $
-            parseAndLex pReturnStatement "return a"
+            parseAndLex pStatement "return a;"
             `shouldLexParse` sRet (eaId "a")
         it "var decl statement (no value)" $
-            parseAndLex pVariableDeclStatement "i32 myint"
+            parseAndLex pStatement "i32 myint;"
             `shouldLexParse` sDecl (tId "i32") (vId "myint") Nothing
         it "var decl statement with initialiser" $
-            parseAndLex pVariableDeclStatement "i32 myint = 42"
+            parseAndLex pStatement "i32 myint = 42\n"
             `shouldLexParse` sDecl
                 (tId "i32")
                 (vId "myint")

--- a/test/ParserSpec.hs
+++ b/test/ParserSpec.hs
@@ -12,7 +12,8 @@ import Test.Hspec (
     Spec,
     describe,
     it,
-    shouldBe
+    shouldBe,
+    context,
     )
 import Text.Megaparsec (ShowErrorComponent, VisualStream, TraversableStream, ParseErrorBundle, errorBundlePretty, parse, Parsec)
 import Parser2 (
@@ -213,6 +214,20 @@ spec = do
                 (tId "i32")
                 (vId "myint")
                 (Just $ eaInt 42)
+        context "assignment statement" $ do
+            it "basic succes" $
+                parseAndLex pStatement "abc = 4;"
+                `shouldLexParse` sAssi "abc" (eaInt 4)
+            it "assign to function call" $
+                parseAndLex pStatement "x = f(a, b)\n"
+                `shouldLexParse` sAssi "x" (eCall (eaId "f") [eaId "a", eaId "b"])
+            it "missing expression" $
+                lexParse pStatement "myvar =;"
+                `shouldFailWith` err 2 (
+                    utok (withPos 1 8 1 9 1 (Control Semicolon))
+                    <> elabel "expression"
+                )
+
 
     describe "block expressions" $ do
         it "empty block" $

--- a/test/ParserSpec.hs
+++ b/test/ParserSpec.hs
@@ -19,11 +19,19 @@ import Parser2 (
     pExpression,
     pExpression,
     pTypeIdentifier,
-    pVariableDecl, pReturnStatement, pVariableDeclStatement, pBlockExpression, pFunction, pMainFunction, pProgram
+    pVariableDecl,
+    pReturnStatement,
+    pVariableDeclStatement,
+    pBlockExpression,
+    pFunction,
+    pMainFunction,
+    pProgram,
     )
 import Parser.WithPos(withPos)
 import Lexer (showLexError, alexScanTokens)
-import Lexer.Tokens(Token(Control))
+import Lexer.Tokens (
+    ControlSequence(..),
+    )
 import Parser.ParseAndLex (
     ParseLexError(..),
     parseAndLex,
@@ -32,7 +40,6 @@ import Parser.ParseAndLex (
 import Parser.Shorthands
 import Parser.AST (BlockExpression(BlockExpression), Function (Function), MainFunction (MainFunction), Program (Program))
 import Test.Hspec.Megaparsec (etok, err, utok, shouldFailWith, elabel)
-import Lexer.Tokens (ControlSequence(..), Token (Identifier))
 import Parser.Internal2 (liftMyToken)
 import AlexToParsec (TokenStream(..))
 import Data.Text (Text)


### PR DESCRIPTION
This PR adds an assignment statement to our language, all the way from the grammar to the AST (but does not implement how it should be compiled or executed).

Changes include:
- Addition of the assignment statement in the grammar
- Addition of the assignment statement to the AST data structure
- Addition of the assignment statement to the parser
- Unit testing of the assignment statement parsing (success and error cases)
- Slight refactor of the ParserSpec
